### PR TITLE
Correction of sorts.domainName

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,12 +35,13 @@ var sorts = {
 			log('Warning:', a, 'is not a string')
 			return false;
 		}
-		var aWasWww = a.startsWith('www.')
+		var aWasWww = a.startsWith('www.');
+		var bWasWww = b.startsWith('www.');
 		a = normalizeWww(a);
 		b = normalizeWww(b);
 		// Eg, we are comparing www.foo.com to foo.com
-		if ( a === b ) {
-			return aWasWww
+		if ( a === b && aWasWww !== bWasWww) {
+			return aWasWww ? 1 : -1;
 		}
 
 		// Let's reverse the domain names


### PR DESCRIPTION
`sorts.domainNames` is a compare function passed to `Array.prototype.sort`. So, it should return a number (not boolean) and satisfy several rules like `f(x,x) === 0` which was not the case (for `x = "www.banana.com"`, for example). See https://tc39.github.io/ecma262/#sec-array.prototype.sort for more details.